### PR TITLE
add `Accept-Language` header for Yggdrasil API

### DIFF
--- a/src/NsisoLauncherCore/Net/MojangAPI/Api/Requester.cs
+++ b/src/NsisoLauncherCore/Net/MojangAPI/Api/Requester.cs
@@ -1,6 +1,7 @@
 ﻿using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Net;
 using System.Net.Http;
@@ -65,6 +66,9 @@ namespace NsisoLauncherCore.Net.MojangApi.Api
                     //application/x-www-form-urlencoded
                     Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", endpoint.Arguments[0]);
                     Client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("*/*"));
+                    Client.DefaultRequestHeaders.AcceptLanguage.Add(
+                        new StringWithQualityHeaderValue(CultureInfo.CurrentCulture.Name)
+                    );
                     Client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue(ClientName, ClientVersion));
                 }
 
@@ -120,6 +124,10 @@ namespace NsisoLauncherCore.Net.MojangApi.Api
 
             try
             {
+                Client.DefaultRequestHeaders.AcceptLanguage.Add(
+                    new StringWithQualityHeaderValue(CultureInfo.CurrentCulture.Name)
+                );
+
                 StringContent contents = new StringContent(endpoint.PostContent, Encoding, "application/json");
                 httpResponse = await Client.PostAsync(endpoint.Address, contents);
                 rawMessage = await httpResponse.Content.ReadAsStringAsync();
@@ -176,6 +184,9 @@ namespace NsisoLauncherCore.Net.MojangApi.Api
                 //application/x-www-form-urlencoded
                 Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", endpoint.Arguments[0]);
                 Client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("*/*"));
+                Client.DefaultRequestHeaders.AcceptLanguage.Add(
+                    new StringWithQualityHeaderValue(CultureInfo.CurrentCulture.Name)
+                );
                 Client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue(ClientName, ClientVersion));
 
                 httpResponse = await Client.PostAsync(endpoint.Address, new FormUrlEncodedContent(toEncode));
@@ -247,6 +258,9 @@ namespace NsisoLauncherCore.Net.MojangApi.Api
                 //application/x-www-form-urlencoded
                 Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", endpoint.Arguments[0]);
                 Client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("*/*"));
+                Client.DefaultRequestHeaders.AcceptLanguage.Add(
+                    new StringWithQualityHeaderValue(CultureInfo.CurrentCulture.Name)
+                );
                 Client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue(ClientName, ClientVersion));
 
 
@@ -320,6 +334,9 @@ namespace NsisoLauncherCore.Net.MojangApi.Api
                 //application/x-www-form-urlencoded
                 Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", endpoint.Arguments[0]);
                 Client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("*/*"));
+                Client.DefaultRequestHeaders.AcceptLanguage.Add(
+                    new StringWithQualityHeaderValue(CultureInfo.CurrentCulture.Name)
+                );
                 Client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue(ClientName, ClientVersion));
 
                 httpResponse = await Client.DeleteAsync(endpoint.Address);


### PR DESCRIPTION
由于 Blessing Skin 支持多种语言，并且默认的 fallback 语言为英文，所以如果没有设置 `Accept-Language` 头部的话，Yggdrasil API 将会返回英文的消息。

这个 PR 会让启动器通过读取系统当前所使用的语言，并相应的设置 `Accept-Language` 头部。这样中文用户可以得到中文消息，而其它语言（例如英语）则可以获得对应语言的消息。

虽然不是所有使用 Yggdrasil API 的都一定使用 Blessing Skin，但大部分是，而且添加了这个头部也不会带来什么坏处，因此是可行的。